### PR TITLE
MAYH-10989 init data-link-size to skip ether layer when parsing

### DIFF
--- a/src/recv-pfring.c
+++ b/src/recv-pfring.c
@@ -31,6 +31,7 @@ void recv_init()
 		log_fatal("recv", "Could not get packet handle: %s",
 			  strerror(errno));
 	}
+	zconf.data_link_size = sizeof(struct ether_header);
 }
 
 void recv_cleanup()

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -47,7 +47,7 @@
 
 #ifdef PFRING
 #include <pfring_zc.h>
-static int32_t distrib_func(pfring_zc_pkt_buff *pkt, pfring_zc_queue *in_queue,
+static int64_t distrib_func(pfring_zc_pkt_buff *pkt, pfring_zc_queue *in_queue,
 			    void *arg)
 {
 	(void)pkt;

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -874,7 +874,7 @@ int main(int argc, char *argv[])
 	uint32_t total_buffers =
 	    user_buffers + queue_buffers + card_buffers + 2;
 	uint32_t metadata_len = 0;
-	uint32_t numa_node = 0; // TODO
+	uint32_t numa_node = pfring_zc_numa_get_cpu_node(-1);
 	zconf.pf.cluster = pfring_zc_create_cluster(
 	    ZMAP_PF_ZC_CLUSTER_ID, ZMAP_PF_BUFFER_SIZE, metadata_len,
 	    total_buffers, numa_node, NULL);
@@ -900,7 +900,7 @@ int main(int argc, char *argv[])
 	}
 
 	zconf.pf.recv =
-	    pfring_zc_open_device(zconf.pf.cluster, zconf.iface, rx_only, 0);
+	    pfring_zc_open_device(zconf.pf.cluster, zconf.iface, rx_only, PF_RING_ZC_DEVICE_NOT_PROMISC);
 	if (zconf.pf.recv == NULL) {
 		log_fatal("zmap", "Could not open device %s for RX. [%s]",
 			  zconf.iface, strerror(errno));

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -207,7 +207,7 @@ static void start_zmap(void)
 #ifdef PFRING
 	pfring_zc_worker *zw = pfring_zc_run_balancer(
 	    zconf.pf.queues, &zconf.pf.send, zconf.senders, 1,
-	    zconf.pf.prefetches, round_robin_bursts_policy, NULL, distrib_func,
+	    zconf.pf.prefetches, round_robin_bursts_policy, NULL, NULL,
 	    NULL, 0, zconf.pin_cores[cpu & zconf.pin_cores_len]);
 	cpu += 1;
 #endif


### PR DESCRIPTION
Tested on `pippin` with branch `debug_zmap`.
Before the fix:
```
handle_packet: validation_failed: 15
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 16
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 17
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 18
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 19
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 20
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 21
udp_do_validate_packet: not icmp or udp, ip_hdr->ip_p=25
handle_packet: validation_failed: 22
```

After fix, see `validation_passed` in the following logs:
```
handle_packet: validation_passed: 9
handle_packet: response recved.
handle_packet: filter_unsuccessful.
udp_do_validate_packet: valid!!!
handle_packet: validation_passed: 10
handle_packet: response recved.
handle_packet: filter_unsuccessful.
udp_do_validate_packet: valid!!!
handle_packet: validation_passed: 11
handle_packet: response recved.
handle_packet: filter_unsuccessful.
udp_do_validate_packet: valid!!!
handle_packet: validation_passed: 12
handle_packet: response recved.
handle_packet: filter_unsuccessful.
udp_do_validate_packet: valid!!!
handle_packet: validation_passed: 13
```

```
grep validation_passed ~/zmap.zc.debug.log.udp.123.fixed.1 | wc -l
247295
```