### PR TITLE
MAYH-11042 make bitmap output support dynamic

### DIFF
--- a/src/output_modules/module_bitmap.c
+++ b/src/output_modules/module_bitmap.c
@@ -88,10 +88,6 @@ int bitmap_process(fieldset_t *fs)
 		}
 	}
 
-	if (ip_address != NULL) {
-		printf("%s\n", ip_address);
-	}
-
 	uint32_t ip = ntohl(raw_value & 0xffffffff);
 
 	uint64_t l = 1ULL << (ip % 64);
@@ -110,7 +106,7 @@ output_module_t module_bitmap_file = {
     .update_interval = 0,
     .close = &bitmap_close,
     .process_ip = &bitmap_process,
-    .supports_dynamic_output = NO_DYNAMIC_SUPPORT,
+    .supports_dynamic_output = DYNAMIC_SUPPORT,
     .helptext =
 	"Outputs the bitmap of the whole ipv4 address space, each bit represents one \n"
 	"ip address, 1 indicating the existence corresponding ip address, 0 indicating \n"


### PR DESCRIPTION
This is to fix:
```
jwan@pippin:~/scan/zmap$ time sudo ./src/zmap.zc -i zc:enp65s0f0 -M dns -p 53 --source-ip=146.88.240.6 --source-mac=00:e0:ed:42:98:67 --gateway-mac=74:83:ef:19:64:9f 98.0.0.0/8 -f saddr_raw,saddr -O bitmap -o zmap.98.0.0.0_8.53.bmp -v 4 > /tmp/zmap.zc.debug.log.udp.53 2>&1
```
```
jwan@pippin:~/scan/masscan$ tail -f /tmp/zmap.zc.debug.log.udp.53
Feb 17 21:00:56.997 [DEBUG] zmap: zmap main thread started
Feb 17 21:00:56.998 [DEBUG] zmap: Loaded configuration file /etc/zmap/zmap.conf
Feb 17 21:00:56.998 [DEBUG] zmap: syslog support enabled
Feb 17 21:00:56.998 [DEBUG] zmap: requested ouput-module: bitmap
Feb 17 21:00:56.998 [FATAL] zmap: specified probe module (dns) requires dynamic output support, which output module (bitmap) does not support. Most likely you want to use JSON output.
```