### PR TITLE
Faster packet buffer handling

### DIFF
--- a/lib/pbm.c
+++ b/lib/pbm.c
@@ -57,6 +57,14 @@ void pbm_set(uint8_t **b, uint32_t v)
 	bm_set(b[top], bottom);
 }
 
+void pbm_copy(uint8_t **b, uint8_t *out) {
+	for (uint32_t i = 0; i < NUM_PAGES; i++) {
+		if (b[i] != NULL) {
+			memmove(&out[i * PAGE_SIZE_IN_BYTES], b[i], PAGE_SIZE_IN_BYTES);
+		}
+	}
+}
+
 uint32_t pbm_load_from_file(uint8_t **b, char *file)
 {
 	if (!b) {

--- a/lib/pbm.h
+++ b/lib/pbm.h
@@ -6,6 +6,7 @@
 uint8_t **pbm_init(void);
 int pbm_check(uint8_t **b, uint32_t v);
 void pbm_set(uint8_t **b, uint32_t v);
+void pbm_copy(uint8_t **b, uint8_t *out);
 uint32_t pbm_load_from_file(uint8_t **b, char *file);
 
 #endif /* ZMAP_PBM_H */

--- a/src/fieldset.c
+++ b/src/fieldset.c
@@ -27,11 +27,17 @@ void gen_fielddef_set(fielddefset_t *fds, fielddef_t fs[], int len)
 	fds->len += len;
 }
 
+void fs_init_fieldset(fieldset_t *f)
+{
+	memset(f, 0, sizeof(fieldset_t));
+	f->len = 0;
+	f->type = FS_FIELDSET;
+}
+
 fieldset_t *fs_new_fieldset(void)
 {
 	fieldset_t *f = xcalloc(1, sizeof(fieldset_t));
-	f->len = 0;
-	f->type = FS_FIELDSET;
+	fs_init_fieldset(f);
 	return f;
 }
 
@@ -372,17 +378,11 @@ void fs_generate_full_fieldset_translation(translation_t *t,
 	}
 }
 
-fieldset_t *translate_fieldset(fieldset_t *fs, translation_t *t)
+void translate_fieldset(fieldset_t *fs, translation_t *t, fieldset_t *retv)
 {
-	fieldset_t *retv = fs_new_fieldset();
-	if (!retv) {
-		log_fatal("fieldset",
-			  "unable to allocate space for translated field set");
-	}
 	for (int i = 0; i < t->len; i++) {
 		int o = t->translation[i];
 		memcpy(&(retv->fields[i]), &(fs->fields[o]), sizeof(field_t));
 	}
 	retv->len = t->len;
-	return retv;
 }

--- a/src/fieldset.h
+++ b/src/fieldset.h
@@ -80,6 +80,7 @@ typedef struct translation {
 	int translation[MAX_FIELDS];
 } translation_t;
 
+void fs_init_fieldset(fieldset_t *);
 fieldset_t *fs_new_fieldset(void);
 
 fieldset_t *fs_new_repeated_field(int type, int free_);
@@ -138,7 +139,7 @@ void fs_free(fieldset_t *fs);
 void fs_generate_fieldset_translation(translation_t *t, fielddefset_t *avail,
 				      char **req, int reqlen);
 
-fieldset_t *translate_fieldset(fieldset_t *fs, translation_t *t);
+void translate_fieldset(fieldset_t *fs, translation_t *t, fieldset_t *retv);
 
 void fs_generate_full_fieldset_translation(translation_t *t,
 					   fielddefset_t *avail);

--- a/src/probe_modules/probe_modules.c
+++ b/src/probe_modules/probe_modules.c
@@ -77,7 +77,8 @@ void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown)
 {
 	fs_add_bool(fs, "repeat", is_repeat);
 	fs_add_bool(fs, "cooldown", in_cooldown);
-
+	// Note: skip the slow time operations which we don't use, it triples the time.
+#if 0
 	char *timestr = xmalloc(TIMESTR_LEN + 1);
 	char *timestr_ms = xmalloc(TIMESTR_LEN + 1);
 	struct timeval t;
@@ -89,6 +90,7 @@ void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown)
 	fs_add_string(fs, "timestamp_str", timestr_ms, 1);
 	fs_add_uint64(fs, "timestamp_ts", (uint64_t)t.tv_sec);
 	fs_add_uint64(fs, "timestamp_us", (uint64_t)t.tv_usec);
+#endif
 }
 
 int ip_fields_len = 6;

--- a/src/recv-pfring.c
+++ b/src/recv-pfring.c
@@ -40,6 +40,7 @@ void recv_cleanup()
 		return;
 	}
 	pfring_zc_sync_queue(pf_recv, rx_only);
+	pfring_zc_release_packet_handle(zconf.pf.cluster, pf_buffer);
 }
 
 void recv_packets()

--- a/src/state.h
+++ b/src/state.h
@@ -159,27 +159,27 @@ extern struct state_send zsend;
 // global receiver stats
 struct state_recv {
 	// valid responses classified as "success"
-	atomic_uint_fast32_t success_total;
+	uint32_t success_total;
 	// unique IPs that sent valid responses classified as "success"
-	atomic_uint_fast32_t success_unique;
+	uint32_t success_unique;
 	// valid responses classified as "success"
-	atomic_uint_fast32_t app_success_total;
+	uint32_t app_success_total;
 	// unique IPs that sent valid responses classified as "success"
-	atomic_uint_fast32_t app_success_unique;
+	uint32_t app_success_unique;
 	// valid responses classified as "success" received during cooldown
-	atomic_uint_fast32_t cooldown_total;
+	uint32_t cooldown_total;
 	// unique IPs that first sent valid "success"es during cooldown
-	atomic_uint_fast32_t cooldown_unique;
+	uint32_t cooldown_unique;
 	// valid responses NOT classified as "success"
-	atomic_uint_fast32_t failure_total;
+	uint32_t failure_total;
 	// valid responses that passed the filter
-	atomic_uint_fast32_t filter_success;
+	uint32_t filter_success;
 	// how many packets did we receive that were marked as being the first
 	// fragment in a stream
-	atomic_uint_fast32_t ip_fragments;
+	uint32_t ip_fragments;
 	// metrics about _only_ validate_packet
-	atomic_uint_fast32_t validation_passed;
-	atomic_uint_fast32_t validation_failed;
+	uint32_t validation_passed;
+	uint32_t validation_failed;
 
 	int complete;  // has the scanner finished sending?
 	double start;  // timestamp of when recv started

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -292,6 +292,11 @@ static void start_zmap(void)
 		zconf.probe_module->close(&zconf, &zsend, &zrecv);
 	}
 #ifdef PFRING
+	for (uint32_t i = 0; i < zconf.senders * 256; ++i) {
+		pfring_zc_release_packet_handle(zconf.pf.cluster, zconf.pf.buffers[i]);
+	}
+	log_info("zmap", "sleep to let pfring cooling down");
+	sleep(5);
 	pfring_zc_destroy_cluster(zconf.pf.cluster);
 #endif
 	log_info("zmap", "completed");


### PR DESCRIPTION
```
time sudo ./src/zmap.zc -i zc:ens2f0 -M tcp_synscan -p 443 --seed=1337 --shards=1 --shard=0 --source-ip=146.88.240.4 --source-mac=8c:dc:d4:a9:ee:94 --gateway-mac=74:83:ef:19:64:9f 0.0.0.0/0 -O bitmap -o zmap.0.0.0.0_0.443.bmp.ens2f0.7Gbps -v 4 > /tmp/zmap.zc.debug.log.tcp.443.ens2f0.7Gbps.no_handlePacket_test 2>&1

real    9m53.862s
user    19m49.684s
sys    0m24.320s
```
```
jwan@samwise:~/scan/zmap$ cat zmap.0.0.0.0_0.443.bmp.ens2f0.7Gbps | asif dump-bitmap | wc -l
49613559
```