### PR TITLE
Output stats

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -458,6 +458,7 @@ void monitor_run(iterator_t *it, pthread_mutex_t *lock)
 		if (status_fd) {
 			update_status_updates_file(export_status, status_fd);
 		}
+		update_stats();
 		sleep(UPDATE_INTERVAL);
 	}
 	if (!zconf.quiet) {

--- a/src/state.h
+++ b/src/state.h
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <stdatomic.h>
 
 #include "../lib/includes.h"
 
@@ -194,5 +195,13 @@ struct state_recv {
 	uint32_t pcap_ifdrop;
 };
 extern struct state_recv zrecv;
+
+#define STATS_NAME "stats"
+typedef struct stats_st {
+	atomic_int_fast64_t sent;
+	atomic_int_fast64_t recv;
+} stats_t;
+void init_stats();
+void update_stats();
 
 #endif // _STATE_H

--- a/src/zmap.c
+++ b/src/zmap.c
@@ -183,6 +183,8 @@ static void start_zmap(void)
 		zconf.output_module->start(&zconf, &zsend, &zrecv);
 	}
 
+	init_stats();
+
 	// start threads
 	uint32_t cpu = 0;
 	pthread_t *tsend, trecv, tmon;


### PR DESCRIPTION
Tested on `samwise`, when scanning, checking the stats content:
```
root@samwise:/# while :
> do
> xxd stats
> sleep 1
> done
00000000: 0000 0000 0000 0000 aa20 3200 0000 0000  ......... 2.....
00000000: 0000 0000 0000 0000 1786 3200 0000 0000  ..........2.....
00000000: 0000 0000 0000 0000 41ec 3200 0000 0000  ........A.2.....
00000000: 0000 0000 0000 0000 5c08 3300 0000 0000  ........\.3.....
00000000: 0000 0000 0000 0000 5c08 3300 0000 0000  ........\.3.....
00000000: 0000 0000 0000 0000 5c08 3300 0000 0000  ........\.3.....
00000000: 0000 0000 0000 0000 a34d 3300 0000 0000  .........M3.....
00000000: 0000 0000 0000 0000 23b2 3300 0000 0000  ........#.3.....
00000000: 0000 0000 0000 0000 ac14 3400 0000 0000  ..........4.....
```