### PR TITLE
udp_pkt_size to use actual recieved size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,14 @@ RUN apt-get -qqy install build-essential cmake libgmp3-dev gengetopt libpcap-dev
 # a running container and zmap will stop.
 RUN apt-get -qqy install python-dev python-pip
 RUN pip install dumb-init
-RUN wget -q https://github.com/zmap/zmap/archive/${ZMAP_COMMIT}.zip && unzip -q ${ZMAP_COMMIT}.zip && cd zmap-${ZMAP_COMMIT} && (cmake . && make -j4 && make install) 2>&1 > /dev/null
+#RUN wget -q https://github.com/zmap/zmap/archive/${ZMAP_COMMIT}.zip && unzip -q ${ZMAP_COMMIT}.zip && cd zmap-${ZMAP_COMMIT} && (cmake . && make -j4 && make install) 2>&1 > /dev/null
+ADD ./ /zmap
 
+# run
+# docker run --network=host --cap-add ALL -it <ID> /bin/bash
+# cd zmap
+# rm CMakeCache.txt
+# cmake .
+# make -j4
+# dd if=/dev/zero of=stats count=1024 bs=1
+# ./src/zmap --max-targets=1% --bandwidth=900M --verbosity 9 --probe-args=hex:c8020038000000000000000080080000000000018008000000020100800a00000007322e616d800a00000003000000018008000000090023 --cooldown-time=10 --output-filter="success = 1" --probe-module=udp --target-port=1701 --source-port=1701 --output-file=test_scan --output-module=csv --output-fields=saddr,data,sport,dport,udp_pkt_size,udp_pkt_header_size,success 0.0.0.0/0


### PR DESCRIPTION
why we need it - some servers send UDP packets with bad length:

csv file format - saddr,data,sport,dport,udp_pkt_size,success

cat 3478_auth* | grep -v ",," | grep -v udp | sed 's/,/ /g' | awk '{if(length($2)/2 != int($5)-8)print $0;}' | head
209.124.152.2 45000040d43100000011f89c9258f002d17c9a07867b0d96002c000000030010 2816 52171 37123 1
67.59.100.58 45000040d43100000011fd049258f002d17c959fc40c0d96002c000000030010 2816 37411 36858 1
209.124.152.2 45000044d43100000011f8989258f002d17c9a07e0b80d960030000000030014 2816 39928 53628 1
209.124.152.2 45000040d43100000011f89c9258f002d17c9a07e6580d96002c000000030010 2816 38489 59611 1
67.59.100.105 4500004cd43100000011b8259258f002433b68b4d5150d96003800000003001c 2816 52200 49444 1

test:

./src/zmap --max-targets=1% --bandwidth=900M --config=/user/zmap_noz.conf --verbosity 9 --probe-args=hex:c8020038000000000000000080080000000000018008000000020100800a00000007322e616d800a00000003000000018008000000090023 --cooldown-time=10 --output-filter="success = 1" --probe-module=udp --target-port=1701 --source-port=1701 --output-file=test_scan --output-module=csv --output-fields=saddr,data,sport,dport,udp_pkt_size,udp_pkt_header_size,success 0.0.0.0/0
cat test_scan | sed 's/,/ /g' | awk '{if(int($5)-int($6)!=0)print $0;}' | wc -l
0