### PR TITLE
DNS Module

### DIFF
--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -80,6 +80,7 @@ typedef uint8_t bool;
 probe_module_t module_dns;
 static int num_ports;
 
+// char default_domain[16];
 const char default_domain[] = "FFEEFFEE.asert-dns-research.com";
 const uint16_t default_qtype = DNS_QTYPE_A;
 
@@ -89,6 +90,23 @@ static uint16_t *qname_lens;
 static char **qnames;
 static uint16_t *qtypes;
 static int num_questions = 0;
+
+// Fix for dns-hijacking
+/* void generate_default_domain() { */
+/* 	static const char *candidate_domains[] = { */
+/* 		"www.test.com", */
+/* 		"www.dict.com", */
+/* 		"www.food.com", */
+/* 		"www.book.com", */
+/* 		"www.leaf.com", */
+/* 		"www.hope.com" */
+/* 	}; */
+/* 	time_t t; */
+/* 	srand((unsigned) time(&t)); */
+/* 	const char *chosen = candidate_domains[rand() % (sizeof(candidate_domains) / sizeof(candidate_domains[0]))]; */
+/* 	strncpy(default_domain, chosen, sizeof(default_domain) - 1); */
+/* 	log_info("dns", "generate_default_domain: %s", default_domain); */
+/* } */
 
 /* Array of qtypes we support. Jumping through some hoops (1 level of
  * indirection) so the per-packet processing time is fast. Keep this in sync
@@ -514,8 +532,9 @@ static bool process_response_answer(char **data, uint16_t *data_len,
 		} else if (rdlength == 0) {
 		  log_warn("dns",
 			   "TXT record with no length. Not Processing");
-		  fs_add_uint64(afs, "rdata_is_parsed", 0);
-		} else {
+		  fs_add_uint64(afs, "rdata_is_parsed", 0); }
+		
+		else {
 			fs_add_uint64(afs, "rdata_is_parsed", 1);
 			char *txt = xmalloc(rdlength);
 			memcpy(txt, rdata + 1, rdlength - 1);
@@ -590,6 +609,7 @@ static int dns_global_initialize(struct state_conf *conf)
 	char *qtype_str = NULL;
 	char **domains = (char **)xmalloc(sizeof(char *) * num_questions);
 
+	// generate_default_domain();
 	for (int i = 0; i < num_questions; i++) {
 		domains[i] = (char *)default_domain;
 		qtypes[i] = default_qtype;
@@ -733,9 +753,8 @@ int dns_init_perthread(void *buf, macaddr_t *src, macaddr_t *gw,
 	return EXIT_SUCCESS;
 }
 
-int dns_make_packet(void *buf, size_t *buf_len,
-            ipaddr_n_t src_ip, ipaddr_n_t dst_ip, uint8_t ttl,
-			uint32_t *validation, int probe_num,
+int dns_make_packet(void *buf, size_t *buf_len, ipaddr_n_t src_ip,
+		    ipaddr_n_t dst_ip, uint32_t *validation, int probe_num,
 		    UNUSED void *arg)
 {
 	struct ether_header *eth_header = (struct ether_header *)buf;
@@ -768,7 +787,7 @@ int dns_make_packet(void *buf, size_t *buf_len,
 
 	ip_header->ip_src.s_addr = src_ip;
 	ip_header->ip_dst.s_addr = dst_ip;
-	ip_header->ip_ttl = ttl;
+     
 	udp_header->uh_sport =
 	    htons(get_src_port(num_ports, probe_num, validation));
 
@@ -789,6 +808,7 @@ int dns_make_packet(void *buf, size_t *buf_len,
 	char *qname_p = NULL;
 	qname_p = (char *)dns_header_p + sizeof(dns_header);
 	strncpy(qname_p +1, subdomain, 8);
+	
 	
 	ip_header->ip_sum = 0;
 	ip_header->ip_sum = zmap_ip_checksum((unsigned short *)ip_header);
@@ -880,8 +900,7 @@ int dns_validate_packet(const struct ip *ip_hdr, uint32_t len, uint32_t *src_ip,
 }
 
 void dns_process_packet(const u_char *packet, uint32_t len, fieldset_t *fs,
-			uint32_t *validation,
-			__attribute__((unused)) struct timespec ts)
+			uint32_t *validation)
 {
 	struct ip *ip_hdr = (struct ip *)&packet[sizeof(struct ether_header)];
 	if (ip_hdr->ip_p == IPPROTO_UDP) {
@@ -910,16 +929,15 @@ void dns_process_packet(const u_char *packet, uint32_t len, fieldset_t *fs,
 							  sizeof(dns_header) +
 							  qname_lens[i]);
 				// Verify our qname
-				/*
-				if (strcmp(qnames[i], qname_p) == 0) {
-					// Verify the qtype and qclass.
-					if (tail_p->qtype == htons(qtypes[i]) &&
-					    tail_p->qclass == htons(0x01)) {
-						is_valid = 1;
-						break;
-					}} */
+				/* if (strcmp(qnames[i], qname_p) == 0) { */
+				/* 	// Verify the qtype and qclass. */
+				/* 	if (tail_p->qtype == htons(qtypes[i]) && */
+				/* 	    tail_p->qclass == htons(0x01)) { */
+				/* 		is_valid = 1; */
+				/* 		break; */
+				/* 	} */
+				/* } */
 				is_valid = 1;
-
 			}
 		}
 		assert(match > 0);

--- a/src/probe_modules/module_dns.c
+++ b/src/probe_modules/module_dns.c
@@ -91,23 +91,6 @@ static char **qnames;
 static uint16_t *qtypes;
 static int num_questions = 0;
 
-// Fix for dns-hijacking
-/* void generate_default_domain() { */
-/* 	static const char *candidate_domains[] = { */
-/* 		"www.test.com", */
-/* 		"www.dict.com", */
-/* 		"www.food.com", */
-/* 		"www.book.com", */
-/* 		"www.leaf.com", */
-/* 		"www.hope.com" */
-/* 	}; */
-/* 	time_t t; */
-/* 	srand((unsigned) time(&t)); */
-/* 	const char *chosen = candidate_domains[rand() % (sizeof(candidate_domains) / sizeof(candidate_domains[0]))]; */
-/* 	strncpy(default_domain, chosen, sizeof(default_domain) - 1); */
-/* 	log_info("dns", "generate_default_domain: %s", default_domain); */
-/* } */
-
 /* Array of qtypes we support. Jumping through some hoops (1 level of
  * indirection) so the per-packet processing time is fast. Keep this in sync
  * with: dns_qtype (.h) qtype_strid_to_qtype (below) qtype_qtype_to_strid
@@ -928,15 +911,7 @@ void dns_process_packet(const u_char *packet, uint32_t len, fieldset_t *fs,
 				    (dns_question_tail *)(dns_packets[i] +
 							  sizeof(dns_header) +
 							  qname_lens[i]);
-				// Verify our qname
-				/* if (strcmp(qnames[i], qname_p) == 0) { */
-				/* 	// Verify the qtype and qclass. */
-				/* 	if (tail_p->qtype == htons(qtypes[i]) && */
-				/* 	    tail_p->qclass == htons(0x01)) { */
-				/* 		is_valid = 1; */
-				/* 		break; */
-				/* 	} */
-				/* } */
+
 				is_valid = 1;
 			}
 		}


### PR DESCRIPTION
This changes the DNS module to generate a subdomain based on the IP of the device being scanned and requesting resolution to a domain we own. 

This allows us to do a couple of things:

1. We see which servers end up reaching out to our DNS resolver and can be classified as open revolvers
2. We see which domains and up resolving our requests and whether they atch the domain we queried
3. We're not potentially spamming other DNS servers on the internet
